### PR TITLE
Compare FitMethod enum value to correct string

### DIFF
--- a/Pathfinder-Java/src/native/c/pathfinder_java.c
+++ b/Pathfinder-Java/src/native/c/pathfinder_java.c
@@ -50,9 +50,9 @@ fitmethod getFitMethod(JNIEnv *env, jobject obj) {
     
     fitmethod method;
     
-    if (strcmp(nativeString, "FIT_HERMITE_CUBIC") == 0) {
+    if (strcmp(nativeString, "HERMITE_CUBIC") == 0) {
         method = FIT_HERMITE_CUBIC;
-    } else if (strcmp(nativeString, "FIT_HERMITE_QUINTIC") == 0) {
+    } else if (strcmp(nativeString, "HERMITE_QUINTIC") == 0) {
         method = FIT_HERMITE_QUINTIC;
     } else {
         method = FIT_HERMITE_CUBIC;


### PR DESCRIPTION
Previously, the native JNI code compared the `FitMethod` enum value with the strings "FIT_HERMITE_CUBIC" and "FIT_HERMITE_QUINTIC," however these should be "HERMITE_CUBIC" and "HERMITE_QUINTIC" respectively (to match the names in the Java source code). This caused a bug in which it's impossible to select the quintic method.

I corrected this in the JNI code, not the Java code, so existing users of library don't need to make changes.