### PR TITLE
Javadoc fixes

### DIFF
--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/Pathfinder.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/Pathfinder.java
@@ -14,8 +14,8 @@ public class Pathfinder {
     /**
      * Convert degrees to radians. This is included here for static imports. In this library, all angle values are
      * given in radians
-	 * @param degrees the degrees input
-	 * @return the input in radians
+     * @param degrees the degrees input
+     * @return the input in radians
      */
     public static double d2r(double degrees) {
         return Math.toRadians(degrees);
@@ -23,8 +23,8 @@ public class Pathfinder {
 
     /**
      * Convert radians to degrees. This is included here for static imports.
-	 * @param radians the radians input
-	 * @return the input in degrees
+     * @param radians the radians input
+     * @return the input in degrees
      */
     public static double r2d(double radians) {
         return Math.toDegrees(radians);

--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/Pathfinder.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/Pathfinder.java
@@ -14,6 +14,8 @@ public class Pathfinder {
     /**
      * Convert degrees to radians. This is included here for static imports. In this library, all angle values are
      * given in radians
+	 * @param degrees the degrees input
+	 * @return the input in radians
      */
     public static double d2r(double degrees) {
         return Math.toRadians(degrees);
@@ -21,6 +23,8 @@ public class Pathfinder {
 
     /**
      * Convert radians to degrees. This is included here for static imports.
+	 * @param radians the radians input
+	 * @return the input in degrees
      */
     public static double r2d(double radians) {
         return Math.toDegrees(radians);
@@ -28,6 +32,8 @@ public class Pathfinder {
 
     /**
      * Bound an angle (in degrees) to -180 to 180 degrees.
+	 * @param angle_degrees an input angle in degrees
+	 * @return the bounded angle
      */
     public static double boundHalfDegrees(double angle_degrees) {
         while (angle_degrees >= 180.0) angle_degrees -= 360.0;

--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/followers/DistanceFollower.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/followers/DistanceFollower.java
@@ -25,6 +25,7 @@ public class DistanceFollower {
 
     /**
      * Set a new trajectory to follow, and reset the cumulative errors and segment counts
+	 * @param traj a previously generated trajectory
      */
     public void setTrajectory(Trajectory traj) {
         this.trajectory = traj;

--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/followers/DistanceFollower.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/followers/DistanceFollower.java
@@ -25,7 +25,7 @@ public class DistanceFollower {
 
     /**
      * Set a new trajectory to follow, and reset the cumulative errors and segment counts
-	 * @param traj a previously generated trajectory
+     * @param traj a previously generated trajectory
      */
     public void setTrajectory(Trajectory traj) {
         this.trajectory = traj;

--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/followers/EncoderFollower.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/followers/EncoderFollower.java
@@ -28,6 +28,7 @@ public class EncoderFollower {
 
     /**
      * Set a new trajectory to follow, and reset the cumulative errors and segment counts
+	 * @param traj a previously generated trajectory
      */
     public void setTrajectory(Trajectory traj) {
         this.trajectory = traj;

--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/followers/EncoderFollower.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/followers/EncoderFollower.java
@@ -28,7 +28,7 @@ public class EncoderFollower {
 
     /**
      * Set a new trajectory to follow, and reset the cumulative errors and segment counts
-	 * @param traj a previously generated trajectory
+     * @param traj a previously generated trajectory
      */
     public void setTrajectory(Trajectory traj) {
         this.trajectory = traj;

--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/modifiers/SwerveModifier.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/modifiers/SwerveModifier.java
@@ -56,7 +56,7 @@ public class SwerveModifier {
 
     /**
      * Get the initial source trajectory
-	 * @return the source trajectory
+     * @return the source trajectory
      */
     public Trajectory getSourceTrajectory() {
         return source;
@@ -64,7 +64,7 @@ public class SwerveModifier {
 
     /**
      * Get the trajectory for the front-left wheel of the drive base
-	 * @return a trajectory for the front left
+     * @return a trajectory for the front left
      */
     public Trajectory getFrontLeftTrajectory() {
         return fl;
@@ -72,7 +72,7 @@ public class SwerveModifier {
 
     /**
      * Get the trajectory for the front-right wheel of the drive base
-	 * @return a trajectory for the front right
+     * @return a trajectory for the front right
      */
     public Trajectory getFrontRightTrajectory() {
         return fr;
@@ -80,7 +80,7 @@ public class SwerveModifier {
 
     /**
      * Get the trajectory for the back-left wheel of the drive base
-	 * @return a trajectory for the back left
+     * @return a trajectory for the back left
      */
     public Trajectory getBackLeftTrajectory() {
         return bl;
@@ -88,7 +88,7 @@ public class SwerveModifier {
 
     /**
      * Get the trajectory for the back-right wheel of the drive base
-	 * @return a trajectory for the back right
+     * @return a trajectory for the back right
      */
     public Trajectory getBackRightTrajectory() {
         return br;

--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/modifiers/SwerveModifier.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/modifiers/SwerveModifier.java
@@ -56,6 +56,7 @@ public class SwerveModifier {
 
     /**
      * Get the initial source trajectory
+	 * @return the source trajectory
      */
     public Trajectory getSourceTrajectory() {
         return source;
@@ -63,6 +64,7 @@ public class SwerveModifier {
 
     /**
      * Get the trajectory for the front-left wheel of the drive base
+	 * @return a trajectory for the front left
      */
     public Trajectory getFrontLeftTrajectory() {
         return fl;
@@ -70,6 +72,7 @@ public class SwerveModifier {
 
     /**
      * Get the trajectory for the front-right wheel of the drive base
+	 * @return a trajectory for the front right
      */
     public Trajectory getFrontRightTrajectory() {
         return fr;
@@ -77,6 +80,7 @@ public class SwerveModifier {
 
     /**
      * Get the trajectory for the back-left wheel of the drive base
+	 * @return a trajectory for the back left
      */
     public Trajectory getBackLeftTrajectory() {
         return bl;
@@ -84,6 +88,7 @@ public class SwerveModifier {
 
     /**
      * Get the trajectory for the back-right wheel of the drive base
+	 * @return a trajectory for the back right
      */
     public Trajectory getBackRightTrajectory() {
         return br;

--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/modifiers/TankModifier.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/modifiers/TankModifier.java
@@ -39,7 +39,7 @@ public class TankModifier {
 
     /**
      * Get the initial source trajectory
-	 * @return the source trajectory
+     * @return the source trajectory
      */
     public Trajectory getSourceTrajectory() {
         return source;
@@ -47,7 +47,7 @@ public class TankModifier {
 
     /**
      * Get the trajectory for the left side of the drive base
-	 * @return a trajectory for the left side
+     * @return a trajectory for the left side
      */
     public Trajectory getLeftTrajectory() {
         return left;
@@ -55,7 +55,7 @@ public class TankModifier {
 
     /**
      * Get the trajectory for the right side of the drive base
-	 * @return a trajectory for the right side
+     * @return a trajectory for the right side
      */
     public Trajectory getRightTrajectory() {
         return right;

--- a/Pathfinder-Java/src/main/java/jaci/pathfinder/modifiers/TankModifier.java
+++ b/Pathfinder-Java/src/main/java/jaci/pathfinder/modifiers/TankModifier.java
@@ -39,6 +39,7 @@ public class TankModifier {
 
     /**
      * Get the initial source trajectory
+	 * @return the source trajectory
      */
     public Trajectory getSourceTrajectory() {
         return source;
@@ -46,6 +47,7 @@ public class TankModifier {
 
     /**
      * Get the trajectory for the left side of the drive base
+	 * @return a trajectory for the left side
      */
     public Trajectory getLeftTrajectory() {
         return left;
@@ -53,6 +55,7 @@ public class TankModifier {
 
     /**
      * Get the trajectory for the right side of the drive base
+	 * @return a trajectory for the right side
      */
     public Trajectory getRightTrajectory() {
         return right;


### PR DESCRIPTION
This removes javadoc build warnings by adding missing `@param` and `@return` lines.