### PR TITLE
Memleak example fix

### DIFF
--- a/Pathfinder-Core/examples/basic.c
+++ b/Pathfinder-Core/examples/basic.c
@@ -14,7 +14,7 @@ int main() {
     
     TrajectoryCandidate candidate;
     pathfinder_prepare(points, POINT_LENGTH, FIT_HERMITE_CUBIC, PATHFINDER_SAMPLES_HIGH, 0.001, 15.0, 10.0, 60.0, &candidate);
-	free(points);
+    free(points);
 
     int length = candidate.length;
     Segment *trajectory = malloc(length * sizeof(Segment));

--- a/Pathfinder-Core/examples/basic.c
+++ b/Pathfinder-Core/examples/basic.c
@@ -14,6 +14,7 @@ int main() {
     
     TrajectoryCandidate candidate;
     pathfinder_prepare(points, POINT_LENGTH, FIT_HERMITE_CUBIC, PATHFINDER_SAMPLES_HIGH, 0.001, 15.0, 10.0, 60.0, &candidate);
+	free(points);
 
     int length = candidate.length;
     Segment *trajectory = malloc(length * sizeof(Segment));

--- a/Pathfinder-Core/examples/swerve.c
+++ b/Pathfinder-Core/examples/swerve.c
@@ -14,7 +14,7 @@ int main() {
     
     TrajectoryCandidate candidate;
     pathfinder_prepare(points, POINT_LENGTH, FIT_HERMITE_CUBIC, PATHFINDER_SAMPLES_HIGH, 0.001, 15.0, 10.0, 60.0, &candidate);
-	free(points);
+    free(points);
 
     int length = candidate.length;
     Segment *trajectory = malloc(length * sizeof(Segment));
@@ -36,9 +36,9 @@ int main() {
     // Do something with the trajectories...
     
     free(trajectory);
-	free(frontLeft);
-	free(frontRight);
-	free(backLeft);
-	free(backRight);
+    free(frontLeft);
+    free(frontRight);
+    free(backLeft);
+    free(backRight);
     return 0;
 }

--- a/Pathfinder-Core/examples/swerve.c
+++ b/Pathfinder-Core/examples/swerve.c
@@ -14,6 +14,7 @@ int main() {
     
     TrajectoryCandidate candidate;
     pathfinder_prepare(points, POINT_LENGTH, FIT_HERMITE_CUBIC, PATHFINDER_SAMPLES_HIGH, 0.001, 15.0, 10.0, 60.0, &candidate);
+	free(points);
 
     int length = candidate.length;
     Segment *trajectory = malloc(length * sizeof(Segment));
@@ -35,5 +36,9 @@ int main() {
     // Do something with the trajectories...
     
     free(trajectory);
+	free(frontLeft);
+	free(frontRight);
+	free(backLeft);
+	free(backRight);
     return 0;
 }

--- a/Pathfinder-Core/examples/tank.c
+++ b/Pathfinder-Core/examples/tank.c
@@ -14,7 +14,7 @@ int main() {
     
     TrajectoryCandidate candidate;
     pathfinder_prepare(points, POINT_LENGTH, FIT_HERMITE_CUBIC, PATHFINDER_SAMPLES_HIGH, 0.001, 15.0, 10.0, 60.0, &candidate);
-	free(points);
+    free(points);
 
     int length = candidate.length;
     Segment *trajectory = malloc(length * sizeof(Segment));
@@ -31,7 +31,7 @@ int main() {
     // Do something with the trajectories...
     
     free(trajectory);
-	free(leftTrajectory);
-	free(rightTrajectory);
+    free(leftTrajectory);
+    free(rightTrajectory);
     return 0;
 }

--- a/Pathfinder-Core/examples/tank.c
+++ b/Pathfinder-Core/examples/tank.c
@@ -14,6 +14,7 @@ int main() {
     
     TrajectoryCandidate candidate;
     pathfinder_prepare(points, POINT_LENGTH, FIT_HERMITE_CUBIC, PATHFINDER_SAMPLES_HIGH, 0.001, 15.0, 10.0, 60.0, &candidate);
+	free(points);
 
     int length = candidate.length;
     Segment *trajectory = malloc(length * sizeof(Segment));
@@ -30,5 +31,7 @@ int main() {
     // Do something with the trajectories...
     
     free(trajectory);
+	free(leftTrajectory);
+	free(rightTrajectory);
     return 0;
 }


### PR DESCRIPTION
Add free statements for the `points` array used in setting up the initial trajectory, as well as the modified trajectories generated via tank and swerve modifiers.