### PR TITLE
Remove unusued variable in pathfinder_generate()

### DIFF
--- a/Pathfinder-Core/src/generator.c
+++ b/Pathfinder-Core/src/generator.c
@@ -62,7 +62,6 @@ int pathfinder_generate_LabVIEW(Segment *segments)
 int pathfinder_generate(TrajectoryCandidate *c, Segment *segments) {
     int trajectory_length = c->length;
     int path_length = c->path_length;
-    double totalLength = c->totalLength;
     
     Spline *splines = (c->saptr);
     double *splineLengths = (c->laptr);


### PR DESCRIPTION
Clang's static analyzer (`scan-build`) pointed this out, so I am sending the fix upstream.